### PR TITLE
Fix GitHub Actions Dependabot Labels Issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,6 @@ updates:
     open-pull-requests-limit: 3
     labels:
       - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
Dependabot was failing with "The following labels could not be found: github-actions" because this label doesn't exist in the repository. Removed it from the configuration to allow Dependabot to successfully create PRs. The 'dependencies' label is sufficient for tracking GitHub Actions updates.