### PR TITLE
Add permissions block to GitHub Actions workflow

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   native-validation:
     name: Validate Extension Native Compatibility with Mandrel ${{ matrix.mandrel-version }}


### PR DESCRIPTION
- Add explicit permissions block with minimal required permissions
- contents: read for checking out code
- actions: write for uploading artifacts
- Follows GitHub security best practices for limiting token scope