### PR TITLE
Fix GitHub Actions Maven deployment authentication error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,13 +52,32 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: 'maven'
 
-      - name: Configure Maven for GitHub Packages
+      - name: Verify Mandrel setup (for native validation)
         if: ${{ inputs.validate-native }}
         run: |
           echo "GRAALVM_HOME: $GRAALVM_HOME"
           echo "JAVA_HOME: $JAVA_HOME"
           java -version
           native-image --version
+
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml << EOF
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>\${env.GITHUB_ACTOR}</username>
+                <password>\${env.GITHUB_TOKEN}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+          echo "Maven settings.xml created with GitHub authentication"
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
…ease workflow

- Configure Maven settings.xml with GitHub authentication for both Temurin and Mandrel paths
- Use environment variables (${env.GITHUB_ACTOR} and ${env.GITHUB_TOKEN}) for credentials
- Fixes 401 Unauthorized error during maven-deploy-plugin execution
- Ensures consistent authentication across all build scenarios (JVM and native)